### PR TITLE
Android Lollipop support (API 21)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ allprojects {
     ext {
         compileSdkVersion = 29
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 23
+        minSdkVersion = 21
         targetSdkVersion = 29
     }
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:4.3.1"
     implementation "com.squareup.okhttp3:okhttp:4.3.1"
     implementation "ru.gildor.coroutines:kotlin-coroutines-okhttp:1.0"
-    implementation "com.google.android.material:material:1.1.0"
-    implementation "androidx.appcompat:appcompat:1.1.0"
+    implementation "com.google.android.material:material:1.2.0"
+    implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
 
     testImplementation "junit:junit:4.12"

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -8,19 +8,23 @@
 
         <activity
             android:name=".checkout.internal.CheckoutActivity"
-            android:configChanges="orientation|screenSize" />
+            android:configChanges="orientation|screenSize|uiMode"
+            android:theme="@style/NoActionBar" />
 
         <activity
             android:name=".paywithpaymaya.internal.SinglePaymentActivity"
-            android:configChanges="orientation|screenSize" />
+            android:configChanges="orientation|screenSize|uiMode"
+            android:theme="@style/NoActionBar" />
 
         <activity
             android:name=".paywithpaymaya.internal.CreateWalletLinkActivity"
-            android:configChanges="orientation|screenSize" />
+            android:configChanges="orientation|screenSize|uiMode"
+            android:theme="@style/NoActionBar" />
 
         <activity
             android:name=".vault.internal.screen.TokenizeCardActivity"
-            android:configChanges="orientation|screenSize" />
+            android:configChanges="orientation|screenSize|uiMode"
+            android:theme="@style/NoActionBar" />
 
     </application>
 

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -8,22 +8,22 @@
 
         <activity
             android:name=".checkout.internal.CheckoutActivity"
-            android:configChanges="orientation|screenSize|uiMode"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/NoActionBar" />
 
         <activity
             android:name=".paywithpaymaya.internal.SinglePaymentActivity"
-            android:configChanges="orientation|screenSize|uiMode"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/NoActionBar" />
 
         <activity
             android:name=".paywithpaymaya.internal.CreateWalletLinkActivity"
-            android:configChanges="orientation|screenSize|uiMode"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/NoActionBar" />
 
         <activity
             android:name=".vault.internal.screen.TokenizeCardActivity"
-            android:configChanges="orientation|screenSize|uiMode"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/NoActionBar" />
 
     </application>

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -8,19 +8,23 @@
 
         <activity
             android:name=".checkout.internal.CheckoutActivity"
-            android:configChanges="orientation|screenSize" />
+            android:configChanges="orientation|screenSize"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
         <activity
             android:name=".paywithpaymaya.internal.SinglePaymentActivity"
-            android:configChanges="orientation|screenSize" />
+            android:configChanges="orientation|screenSize"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
         <activity
             android:name=".paywithpaymaya.internal.CreateWalletLinkActivity"
-            android:configChanges="orientation|screenSize" />
+            android:configChanges="orientation|screenSize"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
         <activity
             android:name=".vault.internal.screen.TokenizeCardActivity"
-            android:configChanges="orientation|screenSize" />
+            android:configChanges="orientation|screenSize"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
 
     </application>
 

--- a/sdk/src/main/AndroidManifest.xml
+++ b/sdk/src/main/AndroidManifest.xml
@@ -8,23 +8,19 @@
 
         <activity
             android:name=".checkout.internal.CheckoutActivity"
-            android:configChanges="orientation|screenSize"
-            android:theme="@style/NoActionBar" />
+            android:configChanges="orientation|screenSize" />
 
         <activity
             android:name=".paywithpaymaya.internal.SinglePaymentActivity"
-            android:configChanges="orientation|screenSize"
-            android:theme="@style/NoActionBar" />
+            android:configChanges="orientation|screenSize" />
 
         <activity
             android:name=".paywithpaymaya.internal.CreateWalletLinkActivity"
-            android:configChanges="orientation|screenSize"
-            android:theme="@style/NoActionBar" />
+            android:configChanges="orientation|screenSize" />
 
         <activity
             android:name=".vault.internal.screen.TokenizeCardActivity"
-            android:configChanges="orientation|screenSize"
-            android:theme="@style/NoActionBar" />
+            android:configChanges="orientation|screenSize" />
 
     </application>
 

--- a/sdk/src/main/java/com/paymaya/sdk/android/common/internal/screen/PayMayaPaymentActivity.kt
+++ b/sdk/src/main/java/com/paymaya/sdk/android/common/internal/screen/PayMayaPaymentActivity.kt
@@ -20,11 +20,15 @@
 package com.paymaya.sdk.android.common.internal.screen
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
+import android.view.MenuItem
 import android.view.View
 import android.webkit.*
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import com.paymaya.sdk.android.BuildConfig
 import com.paymaya.sdk.android.common.LogLevel
 import com.paymaya.sdk.android.common.PayMayaEnvironment
@@ -32,7 +36,7 @@ import com.paymaya.sdk.android.common.internal.models.PayMayaRequest
 import kotlinx.android.synthetic.main.activity_paymaya_payment.*
 
 internal abstract class PayMayaPaymentActivity<R : PayMayaRequest> :
-    Activity(), PayMayaPaymentContract.View {
+    AppCompatActivity(), PayMayaPaymentContract.View {
 
     private lateinit var presenter: PayMayaPaymentContract.Presenter<R>
 
@@ -68,6 +72,16 @@ internal abstract class PayMayaPaymentActivity<R : PayMayaRequest> :
         presenter.backButtonPressed()
     }
 
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                presenter.backButtonPressed()
+                super.onOptionsItemSelected(item)
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
     private fun initializeView() {
         CookieManager.getInstance().setAcceptThirdPartyCookies(payMayaPaymentActivityWebView, true)
         if (BuildConfig.DEBUG) {
@@ -77,6 +91,13 @@ internal abstract class PayMayaPaymentActivity<R : PayMayaRequest> :
         payMayaPaymentActivityWebView.settings.javaScriptEnabled = true
         payMayaPaymentActivityWebView.settings.allowFileAccess = true
         payMayaPaymentActivityWebView.webViewClient = WebViewClientImpl()
+
+        val toolbar = findViewById<Toolbar>(com.paymaya.sdk.android.R.id.toolbar)
+        setSupportActionBar(toolbar)
+        if (supportActionBar != null) {
+            supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+            supportActionBar!!.title = ""
+        }
     }
 
     override fun loadUrl(redirectUrl: String) {

--- a/sdk/src/main/java/com/paymaya/sdk/android/common/internal/screen/PayMayaPaymentActivity.kt
+++ b/sdk/src/main/java/com/paymaya/sdk/android/common/internal/screen/PayMayaPaymentActivity.kt
@@ -92,12 +92,14 @@ internal abstract class PayMayaPaymentActivity<R : PayMayaRequest> :
         payMayaPaymentActivityWebView.settings.allowFileAccess = true
         payMayaPaymentActivityWebView.webViewClient = WebViewClientImpl()
 
+        /* TODO: Make a option to use toolbar (either through config, etc.)
         val toolbar = findViewById<Toolbar>(com.paymaya.sdk.android.R.id.toolbar)
         setSupportActionBar(toolbar)
         supportActionBar?.apply {
           setDisplayHomeAsUpEnabled(true)
           title = ""
         }
+         */
     }
 
     override fun loadUrl(redirectUrl: String) {

--- a/sdk/src/main/java/com/paymaya/sdk/android/common/internal/screen/PayMayaPaymentActivity.kt
+++ b/sdk/src/main/java/com/paymaya/sdk/android/common/internal/screen/PayMayaPaymentActivity.kt
@@ -81,15 +81,6 @@ internal abstract class PayMayaPaymentActivity<R : PayMayaRequest> :
         payMayaPaymentActivityWebView.settings.javaScriptEnabled = true
         payMayaPaymentActivityWebView.settings.allowFileAccess = true
         payMayaPaymentActivityWebView.webViewClient = WebViewClientImpl()
-
-        /* TODO: Make a option to use toolbar (either through config, etc.)
-        val toolbar = findViewById<Toolbar>(com.paymaya.sdk.android.R.id.toolbar)
-        setSupportActionBar(toolbar)
-        supportActionBar?.apply {
-          setDisplayHomeAsUpEnabled(true)
-          title = ""
-        }
-         */
     }
 
     override fun loadUrl(redirectUrl: String) {

--- a/sdk/src/main/java/com/paymaya/sdk/android/common/internal/screen/PayMayaPaymentActivity.kt
+++ b/sdk/src/main/java/com/paymaya/sdk/android/common/internal/screen/PayMayaPaymentActivity.kt
@@ -94,9 +94,9 @@ internal abstract class PayMayaPaymentActivity<R : PayMayaRequest> :
 
         val toolbar = findViewById<Toolbar>(com.paymaya.sdk.android.R.id.toolbar)
         setSupportActionBar(toolbar)
-        if (supportActionBar != null) {
-            supportActionBar!!.setDisplayHomeAsUpEnabled(true)
-            supportActionBar!!.title = ""
+        supportActionBar?.apply {
+          setDisplayHomeAsUpEnabled(true)
+          title = ""
         }
     }
 

--- a/sdk/src/main/java/com/paymaya/sdk/android/common/internal/screen/PayMayaPaymentActivity.kt
+++ b/sdk/src/main/java/com/paymaya/sdk/android/common/internal/screen/PayMayaPaymentActivity.kt
@@ -72,16 +72,6 @@ internal abstract class PayMayaPaymentActivity<R : PayMayaRequest> :
         presenter.backButtonPressed()
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            android.R.id.home -> {
-                presenter.backButtonPressed()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
-
     private fun initializeView() {
         CookieManager.getInstance().setAcceptThirdPartyCookies(payMayaPaymentActivityWebView, true)
         if (BuildConfig.DEBUG) {

--- a/sdk/src/main/java/com/paymaya/sdk/android/common/internal/screen/PayMayaPaymentActivity.kt
+++ b/sdk/src/main/java/com/paymaya/sdk/android/common/internal/screen/PayMayaPaymentActivity.kt
@@ -76,7 +76,7 @@ internal abstract class PayMayaPaymentActivity<R : PayMayaRequest> :
         return when (item.itemId) {
             android.R.id.home -> {
                 presenter.backButtonPressed()
-                super.onOptionsItemSelected(item)
+                true
             }
             else -> super.onOptionsItemSelected(item)
         }

--- a/sdk/src/main/res/layout/activity_paymaya_payment.xml
+++ b/sdk/src/main/res/layout/activity_paymaya_payment.xml
@@ -1,55 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <FrameLayout
+    <WebView
+        android:id="@+id/payMayaPaymentActivityWebView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent" />
 
-        <WebView
-            android:id="@+id/payMayaPaymentActivityWebView"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+    <FrameLayout
+        android:id="@+id/payMayaPaymentActivityProgressBar"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/paymaya_vault_progress_bar_background"
+        android:clickable="true"
+        android:focusable="true">
 
-        <FrameLayout
-            android:id="@+id/payMayaPaymentActivityProgressBar"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/paymaya_vault_progress_bar_background"
-            android:clickable="true"
-            android:focusable="true">
-
-            <ProgressBar style="@style/PayMayaVaultProgressbarBase" />
-
-        </FrameLayout>
-
-        <TextView
-            android:id="@+id/payMayaCheckingPaymentStatusLabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal|bottom"
-            android:layout_marginBottom="48dp"
-            android:text="@string/paymaya_checking_payment_status"
-            android:visibility="gone"
-            tools:visibility="visible" />
-
-        <TextView
-            android:id="@+id/payMayaNoConnectionScreen"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center"
-            android:textColor="#ffffff"
-            android:padding="20dp"
-            android:focusable="true"
-            android:clickable="true"
-            android:text="@string/paymaya_connection_error"
-            android:textSize="20sp"
-            android:background="#80353535"
-            android:visibility="gone"
-            tools:visibility="visible" />
+        <ProgressBar style="@style/PayMayaVaultProgressbarBase" />
 
     </FrameLayout>
 
-</RelativeLayout>
+    <TextView
+        android:id="@+id/payMayaCheckingPaymentStatusLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal|bottom"
+        android:layout_marginBottom="48dp"
+        android:text="@string/paymaya_checking_payment_status"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+    <TextView
+        android:id="@+id/payMayaNoConnectionScreen"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:textColor="#ffffff"
+        android:padding="20dp"
+        android:focusable="true"
+        android:clickable="true"
+        android:text="@string/paymaya_connection_error"
+        android:textSize="20sp"
+        android:background="#80353535"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+</FrameLayout>

--- a/sdk/src/main/res/layout/activity_paymaya_payment.xml
+++ b/sdk/src/main/res/layout/activity_paymaya_payment.xml
@@ -1,49 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <WebView
-        android:id="@+id/payMayaPaymentActivityWebView"
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="?attr/actionBarSize" />
 
     <FrameLayout
-        android:id="@+id/payMayaPaymentActivityProgressBar"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/paymaya_vault_progress_bar_background"
-        android:clickable="true"
-        android:focusable="true">
+        android:layout_marginTop="?attr/actionBarSize">
 
-        <ProgressBar style="@style/PayMayaVaultProgressbarBase" />
+        <WebView
+            android:id="@+id/payMayaPaymentActivityWebView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <FrameLayout
+            android:id="@+id/payMayaPaymentActivityProgressBar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/paymaya_vault_progress_bar_background"
+            android:clickable="true"
+            android:focusable="true">
+
+            <ProgressBar style="@style/PayMayaVaultProgressbarBase" />
+
+        </FrameLayout>
+
+        <TextView
+            android:id="@+id/payMayaCheckingPaymentStatusLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal|bottom"
+            android:layout_marginBottom="48dp"
+            android:text="@string/paymaya_checking_payment_status"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+        <TextView
+            android:id="@+id/payMayaNoConnectionScreen"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:textColor="#ffffff"
+            android:padding="20dp"
+            android:focusable="true"
+            android:clickable="true"
+            android:text="@string/paymaya_connection_error"
+            android:textSize="20sp"
+            android:background="#80353535"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
     </FrameLayout>
 
-    <TextView
-        android:id="@+id/payMayaCheckingPaymentStatusLabel"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal|bottom"
-        android:layout_marginBottom="48dp"
-        android:text="@string/paymaya_checking_payment_status"
-        android:visibility="gone"
-        tools:visibility="visible" />
-
-    <TextView
-        android:id="@+id/payMayaNoConnectionScreen"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:textColor="#ffffff"
-        android:padding="20dp"
-        android:focusable="true"
-        android:clickable="true"
-        android:text="@string/paymaya_connection_error"
-        android:textSize="20sp"
-        android:background="#80353535"
-        android:visibility="gone"
-        tools:visibility="visible" />
-
-</FrameLayout>
+</RelativeLayout>

--- a/sdk/src/main/res/layout/activity_paymaya_payment.xml
+++ b/sdk/src/main/res/layout/activity_paymaya_payment.xml
@@ -4,15 +4,9 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize" />
-
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_marginTop="?attr/actionBarSize">
+        android:layout_height="match_parent">
 
         <WebView
             android:id="@+id/payMayaPaymentActivityWebView"

--- a/sdk/src/main/res/values/styles.xml
+++ b/sdk/src/main/res/values/styles.xml
@@ -1,5 +1,10 @@
 <resources>
 
+    <style name="NoActionBar" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+
     <!-- Screen background -->
     <style name="PayMayaVaultBackgroundBase" parent="PayMayaVaultBackground">
         <item name="android:layout_width">match_parent</item>

--- a/sdk/src/main/res/values/styles.xml
+++ b/sdk/src/main/res/values/styles.xml
@@ -1,10 +1,5 @@
 <resources>
 
-    <style name="NoActionBar" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-    </style>
-
     <!-- Screen background -->
     <style name="PayMayaVaultBackgroundBase" parent="PayMayaVaultBackground">
         <item name="android:layout_width">match_parent</item>


### PR DESCRIPTION
Hi. I wanted to maintain the SDK for older apps such as [REDACTED]Delivery who has an older version of SDK
So here's my proposal PR

Changes:
- Convert `Activity` superclass into `AppCompatActivity`
- Rename `minSdkVersion` into 21
- Added toolbar for older devices who has no virtual navigation bar

Screenshots:
Running Android Lollipop 5.0 on Genymotion Cloud

![Screen Shot 2020-08-26 at 11 20 36 PM](https://user-images.githubusercontent.com/4709030/91374407-ba5b7000-e84a-11ea-838d-4097918f0423.png)
![Screen Shot 2020-08-26 at 11 19 46 PM](https://user-images.githubusercontent.com/4709030/91374400-b6c7e900-e84a-11ea-91da-d16455e4098c.png)
