### PR TITLE
[chore] Upgrades for Jitpack packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # PayMayaSDK
+
+[![Release](https://jitpack.io/v/paymaya/paymaya-android-sdk-v2.svg)](https://jitpack.io/#paymaya/paymaya-android-sdk-v2)
+
 The PayMaya Android SDK is a library that allows you integrate with PayMaya
 payments. It supports following methods:
 * Checkout
@@ -18,7 +21,29 @@ Android OS version 6.0 Marshmallow (API level 23) or higher.
 
 ### Gradle
 
-Refer [here](https://bintray.com/paymaya/maven-android/paymaya-sdk-android/) for the released versions
+#### Jitpack
+
+Refer [here](https://jitpack.io/#paymaya/paymaya-android-sdk-v2) for the released versions.
+
+```
+allprojects {
+    repositories {
+        ...
+        maven { url 'https://jitpack.io' }
+    }
+}
+
+dependencies {
+    implementation 'com.github.paymaya:paymaya-android-sdk-v2:<release tag>'
+}
+```
+
+#### JCenter
+
+> :warning: Support for this repository has been deprecated (see [here](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)).
+> Only versions 2.0.1 below are available in JCenter as read-only. Succeeding patches / releases will be uploaded to repositories documented above.
+
+Refer [here](https://bintray.com/paymaya/maven-android/paymaya-sdk-android/) for the released versions.
 
 ```
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,12 @@ buildscript {
 
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:9.1.1"
-        classpath "gradle.plugin.com.betomorrow.gradle:appcenter-plugin:1.1.18"
+        classpath "gradle.plugin.com.betomorrow.gradle:appcenter-plugin:1.3.0"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
-        classpath "com.novoda:bintray-release:0.9.2"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+jdk:
+  - openjdk8
+install:
+  - echo "Building SDK only for Jitpack"
+  - ./gradlew :sdk:clean :sdk:publishReleasePublicationToMavenLocal

--- a/sdk/publish.gradle
+++ b/sdk/publish.gradle
@@ -1,12 +1,22 @@
-apply plugin: 'com.novoda.bintray-release' 
+apply plugin: 'maven-publish'
 
-publish {
-    userOrg = 'paymaya'
-    groupId = project.groupId
-    repoName = 'maven-android'
-    artifactId = project.artifactId
-    publishVersion = project.versionName
-    licences = ['MIT']
-    desc = 'Android SDK for PayMaya. Accept payments from within your mobile app.'
-    website = 'https://github.com/PayMaya/PayMaya-Android-SDK-v2'
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+
+                groupId = project.groupId
+                artifactId = project.artifactId
+                version = project.versionName
+            }
+            debug(MavenPublication) {
+                from components.debug
+
+                groupId = project.groupId
+                artifactId = project.artifactId + '-debug'
+                version = project.versionName
+            }
+        }
+    }
 }


### PR DESCRIPTION
* Gradle 5.6.4 dependency
* Remove bintray publishing tasks
* Upgrade AGP to 3.6.4
* Add jitpack.yml to build only sdk and skip sdk-demo